### PR TITLE
Docs: correct error codes and clarify request forwardingUpdate README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Ops Defender runs as a **standalone HTTP service** designed to integrate with **
 
 **HTTP-Based Request Flow:**
 
-1. **Proxy forwards request** to Ops Defender `/check` endpoint (via HTTP) Note: When forwarding requests, the request body is excluded
+1. **Proxy forwards request** to Ops Defender `/check` endpoint (via HTTP) Note: Ops Defender avoids working with each request's body. We suggest to exclude it at forwarding time. Our [NGINX conf sample](nginx.con.example) shows how the write off gets implemented.
 2. **Immediate check** for unforgiving patterns (excessive nesting):
    - **First malicious request** → blocked immediately (HTTP 403)
    - Prevents backend from processing dangerous URLs


### PR DESCRIPTION
"Hi @luisgizirian, I have updated the README to remove the incorrect 404 references and added a note that the request body is excluded during forwarding as requested in issue #11."